### PR TITLE
Add default help when no parameter is provided. Added -c parameter to specify cloudfront id.

### DIFF
--- a/bin/s3front
+++ b/bin/s3front
@@ -28,6 +28,7 @@ program
   .option('-r, --region <name>',    'region if not in US standard')
   .option('-i, --invalidate',       'after upload find first cloudfront distribution which has an alias similar to the bucket name and invalidates its content')
   .option('-c, --cloudfront <cloudfront id>', 'cloudfront id (optional)')
+  .option('-p, --path <path>', 'change default path of localfiles')
   .parse(process.argv);
 
 if (!process.argv.slice(2).length) {
@@ -39,6 +40,10 @@ if (!process.argv.slice(2).length) {
 if (!program.key) throw new Error('--key required');
 if (!program.secret) throw new Error('--secret required');
 if (!program.bucket) throw new Error('--bucket required');
+
+if (program.path) {
+  process.chdir(program.path);
+}
 
 console.log('\n');
 

--- a/bin/s3front
+++ b/bin/s3front
@@ -29,6 +29,11 @@ program
   .option('-i, --invalidate',       'after upload find first cloudfront distribution which has an alias similar to the bucket name and invalidates its content')
   .parse(process.argv);
 
+if (!process.argv.slice(2).length) {
+  program.outputHelp();
+  process.exit();
+}
+
 /* ensure required parameters */
 if (!program.key) throw new Error('--key required');
 if (!program.secret) throw new Error('--secret required');
@@ -75,9 +80,9 @@ _.range(Math.ceil(nbFiles / batchSize)).forEach(function(idx) {
       uploads.push(function(cb){
         var file = files[uploadCnt++];
         cache.is(file, function(there) {
-          if (there) { 
+          if (there) {
             if (!quiet) { bar.tick(); }
-            return cb(); 
+            return cb();
           }
 
           var params = {

--- a/bin/s3front
+++ b/bin/s3front
@@ -27,6 +27,7 @@ program
   .option('-q, --quiet',            'quiet mode')
   .option('-r, --region <name>',    'region if not in US standard')
   .option('-i, --invalidate',       'after upload find first cloudfront distribution which has an alias similar to the bucket name and invalidates its content')
+  .option('-c, --cloudfront <cloudfront id>', 'cloudfront id (optional)')
   .parse(process.argv);
 
 if (!process.argv.slice(2).length) {
@@ -117,16 +118,20 @@ async.series(tasks, function(err){
   if (program.invalidate){
     var cf = cloudfront.createClient(program.key, program.secret);
     cf.listDistributions(function(err, list, info) {
-      var distributionId = null;
+      var distributionId = program.cloudfront || null;
+
       /* find first distribution id which has an alias similar to bucket name. */
-      list.some(function(d){
-        return d.config.aliases.some(function(a){
-          if (a === program.bucket) {
-            distributionId = d.id;
-            return true;
-          }
+      if (!program.cloudfront) {
+        list.some(function(d){
+          return d.config.aliases.some(function(a){
+            if (a === program.bucket) {
+              distributionId = d.id;
+              return true;
+            }
+          });
         });
-      });
+      }
+
       /* invalidate content if distribution has been found */
       if (distributionId) {
         cf.createInvalidation(distributionId, uuid.v4(), '/.', function(err, invalidation){
@@ -134,6 +139,9 @@ async.series(tasks, function(err){
           console.log('\n\n  invalidation status:',invalidation.status);
           process.exit();
         });
+      } else {
+        console.log('Couldnt find cloudfront distribution id, you can manually add it with -c');
+        process.exit();
       }
     });
   } else {


### PR DESCRIPTION
Hi, I had to fix this for myself so I thought I might as well pull request it to you.
1. A bit confusing when typing s3front without any parameters. It throws an exception because -k is missing. I prefer to show by default the help message in that case.
2. For me, it couldn't match the right cloudfront distribution to invalidate. I prefer passing the distribution ID, so I added a -c || --cloudfront <id>. Also, there was no error message if no distribution were found so I added an error message and process.exit(). Otherwise it was just hanging.
